### PR TITLE
Redirect to InvalidVin page upon invalid VIN

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import FAQ from "./pages/FAQ"
 import VinCheck from "./pages/VinCheck"
 import ScrollOnTop from "./components/ScrollOnTop"
 import ErrorPage from "./pages/ErrorPage"
+import InvalidVin from "./pages/InvalidVin"
 
 
 function App() {
@@ -27,6 +28,7 @@ function App() {
   <Route path="/about" element={<About />} />
   <Route path="/qa" element={<FAQ />} />
   <Route path="/vin-check/:vinUrl" element={<VinCheck />} />
+  <Route path="/invalid-vin" element={<InvalidVin />} />
 
 
   <Route path="*" element={<ErrorPage />} />

--- a/src/pages/InvalidVin.tsx
+++ b/src/pages/InvalidVin.tsx
@@ -1,0 +1,25 @@
+import { useNavigate } from "react-router";
+
+export default function InvalidVin() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 px-4 text-center">
+      
+      <div className="text-6xl mb-4">🚗💥</div>
+
+      <h1 className="text-3xl font-bold mb-2">VIN Not Found</h1>
+      <p className="text-gray-600 max-w-md mb-6">
+        Sorry, we couldn't find any records for this VIN. Please double-check the number
+        and try again.
+      </p>
+
+      <button
+        onClick={() => navigate('/')}
+        className="bg-amber-300 py-2 px-6 rounded-full font-semibold hover:bg-amber-400 transition"
+      >
+        Go Back
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Task: Create an InvalidVin page to which we can redirect after receiving a VIN which does not apply to any cars

Steps taken:
- InvalidVin page created, styled and made responsive.
- I made the following check - if from the API result there is no car model or a result at all we should navigate to "/invalid-vin" which will lead to the newly created component that shows that there is no data for this VIN number.

Bonus:
- Added abort controller to prevent multiple requests
- A loading spinner added with a setTimeout and a mock delay Promise of 1 sec to make a smooth UX just before redirecting to the car details or InvalidVin page.

I have attached screenshots with the following actions:
- First an invalid vin is inserted and there is a spinner that loads for 1 sec and the user is redirected to InvalidVin.
- Secondly, the same action but with an existing VIN and redirect to the car details.

Summary:
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 21 41" src="https://github.com/user-attachments/assets/967e34d8-08ac-412c-a04b-467aba82204c" />
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 21 44" src="https://github.com/user-attachments/assets/69c62130-b41e-4569-8bde-db115acfd758" />
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 21 46" src="https://github.com/user-attachments/assets/28406315-657c-4a01-a642-abdf2b3cb0d2" />
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 21 54" src="https://github.com/user-attachments/assets/cd807b87-1a76-4ee2-b245-93922515f0e7" />
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 21 57" src="https://github.com/user-attachments/assets/b2cb2646-4033-4144-8c1a-f58750bcac3f" />
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 22 00" src="https://github.com/user-attachments/assets/ccfb4d93-315b-4e0a-8839-9a3a6051a756" />
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 22 04" src="https://github.com/user-attachments/assets/04c5b3cf-cea5-4213-8525-4b51faca5146" />
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 22 20" src="https://github.com/user-attachments/assets/6c608878-65e7-4ebb-84a0-9768ac1733fc" />
<img width="1440" height="900" alt="Screenshot 2025-08-10 at 00 22 30" src="https://github.com/user-attachments/assets/dc760204-bf3e-47b0-b9e9-505791484911" />

